### PR TITLE
Added Bodycam Model Check

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -14,7 +14,7 @@ Config = {
   --- whether the axon overlay is also visible in third person
   --- @type boolean
   ThirdPersonMode = false,
-  CheckModel = true, -- If turned on, it will check if the player wears a bodycam
+  CheckModel = false, -- If turned on, it will check if the player wears a bodycam
   --Format: componentID:drawableID:ABLE TO CHANGE TEXTURE (0 Unable; 1 Fully able; 2 Unable to shut off)
 	bodycam_m = { -- Bodycamcomponent used with mp_m_freemode_01
 

--- a/config.lua
+++ b/config.lua
@@ -14,4 +14,12 @@ Config = {
   --- whether the axon overlay is also visible in third person
   --- @type boolean
   ThirdPersonMode = false,
+  CheckModel = true, -- If turned on, it will check if the player wears a bodycam
+  --Format: componentID:drawableID:ABLE TO CHANGE TEXTURE (0 Unable; 1 Fully able; 2 Unable to shut off)
+	bodycam_m = { -- Bodycamcomponent used with mp_m_freemode_01
+
+	},
+	bodycam_f = { -- Bodycamcomponent used with mp_f_freemode_01
+
+	},  
 }


### PR DESCRIPTION
Since there are server which are using bodycam models, this PR is a optional integration of a check whether the MP Skin is wearing a bodycam or not. This check is added at every point the script is checking for onduty. This is configurable using the config.lua.
If configurated this PR is capable to even change the texture of the bodycam (For Standby, Recording, Off; using texture-ids 0, 1, 2).
It added a /axontoggle command which is only usable wearing a bodycam which has a Shut-Off Texture.

Added a bodycam model check which can be turned on/off configurated in the config.lua